### PR TITLE
let server determine user's ip by itself

### DIFF
--- a/background.js
+++ b/background.js
@@ -46,7 +46,7 @@ chrome.alarms.onAlarm.addListener(function(alarm) {
 
 function updateCsieIoDDNS(ip, token, hostname , noti) {//params.noti can only be true or not set, just for force update
 	var xhr = new XMLHttpRequest();
-	xhr.open('GET', 'https://csie.io/update?hn=' + hostname + '&token=' + token + ((ip)?'&ip='+ip:"")  );
+	xhr.open('GET', 'https://csie.io/update?hn=' + hostname + '&token=' + token + '&ip=' );
 	xhr.onreadystatechange = function() {
 		if (xhr.readyState == XMLHttpRequest.DONE) {
 			if (xhr.status == 200) {


### PR DESCRIPTION
If the given IP is blank, the server will try to get user's external IP by itself. Hence, leaving the "ip" field empty will make life easier.
